### PR TITLE
Normalize phone numbers before importing CDR logs

### DIFF
--- a/FunctionsTest.php
+++ b/FunctionsTest.php
@@ -21,4 +21,11 @@ assert($stats['total_out_time'] === 30);
 assert($stats['total_in_time'] === 120);
 
 
+// phone normalization tests
+assert(normalizePhoneNumber('+41791234567') === '+41791234567');
+assert(normalizePhoneNumber('0041791234567') === '+41791234567');
+assert(normalizePhoneNumber('0791234567') === '+41791234567');
+assert(normalizePhoneNumber('') === 'unknown');
+
 echo "All tests passed\n";
+

--- a/classes/CallImporter.php
+++ b/classes/CallImporter.php
@@ -1,5 +1,7 @@
 <?php
 
+require_once __DIR__ . '/../helpers.php';
+
 class CallImporter
 {
     private DBHandler $db;
@@ -61,6 +63,13 @@ class CallImporter
                     if (count($fields) < 20) {
                         throw new RuntimeException('insufficient fields');
                     }
+
+                    // Normalize phone numbers before inserting
+                    $fields[7]  = normalizePhoneNumber($fields[7]);
+                    $fields[8]  = normalizePhoneNumber($fields[8]);
+                    $fields[11] = normalizePhoneNumber($fields[11]);
+                    $fields[13] = normalizePhoneNumber($fields[13]);
+
                     if (!$dryRun) {
                         $step = 'insert';
                         if (!$this->db->insertCall($fields)) {

--- a/helpers.php
+++ b/helpers.php
@@ -6,3 +6,39 @@ function fmt_duration(int $seconds): string {
     $secs = $seconds % 60;
     return sprintf('%02d:%02d:%02d', $hours, $minutes, $secs);
 }
+
+/**
+ * Normalizes a phone number to international format.
+ *
+ * Accepts numbers such as "+41791234567", "0041791234567" or "0791234567"
+ * and converts them to the uniform "+41791234567" style. Any non-digit
+ * characters are stripped. If the number cannot be interpreted, the string
+ * "unknown" is returned.
+ */
+function normalizePhoneNumber(?string $number): string {
+    $number = trim((string)$number);
+    if ($number === '') {
+        return 'unknown';
+    }
+
+    // Remove spaces, dashes, parentheses, etc., but keep leading '+'
+    $number = preg_replace('/[^\d+]/', '', $number);
+    if ($number === '' || $number === '+') {
+        return 'unknown';
+    }
+
+    if (str_starts_with($number, '+')) {
+        $number = substr($number, 1);
+    } elseif (str_starts_with($number, '00')) {
+        $number = substr($number, 2);
+    } elseif (str_starts_with($number, '0')) {
+        // Assume Swiss local number without country code
+        $number = '41' . substr($number, 1);
+    }
+
+    if ($number === '' || !ctype_digit($number)) {
+        return 'unknown';
+    }
+
+    return '+' . $number;
+}


### PR DESCRIPTION
## Summary
- add normalizePhoneNumber helper to unify local and international formats
- normalize phone fields in CallImporter before DB insert
- cover number normalization with simple assertions

## Testing
- `php FunctionsTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68a5d1977f688329801c87ae125e8808